### PR TITLE
Parse json result with symbolized key names

### DIFF
--- a/lib/searchbing.rb
+++ b/lib/searchbing.rb
@@ -49,7 +49,7 @@ class Bing
   			http.request(req)
 		}
 
-		body = JSON.parse(res.body)
-		result_set = body["d"]["results"]	
+		body = JSON.parse(res.body, :symbolize_names => true)
+		result_set = body[:d][:results]
 	end	
 end


### PR DESCRIPTION
Thanks for the awesome gem.. and how about considering parsing the JSON result's key as a symbol instead?
